### PR TITLE
Rename Amnesia.transaction! to Amnesia.sync_transaction to work around syntax error with Elixir 0.10.1

### DIFF
--- a/lib/amnesia.ex
+++ b/lib/amnesia.ex
@@ -123,7 +123,7 @@ defmodule Amnesia do
   @spec transaction([do: term] | term) :: any | no_return
   defmacro transaction(do: block) do
     quote do
-      :mnesia.transaction(function(do: (() -> unquote(block)))) |> Amnesia.result
+      :mnesia.transaction(fn -> unquote(block) end) |> Amnesia.result
     end
   end
 
@@ -155,14 +155,14 @@ defmodule Amnesia do
   Start a synchronous transaction with the given block or function, see
   `mnesia:sync_transaction`.
   """
-  @spec transaction!([do: term] | term) :: any | no_return
-  defmacro transaction!(do: block) do
+  @spec sync_transaction([do: term] | term) :: any | no_return
+  defmacro sync_transaction(do: block) do
     quote do
-      :mnesia.sync_transaction(function(do: (() -> unquote(block)))) |> Amnesia.result
+      :mnesia.sync_transaction(fn -> unquote(block) end) |> Amnesia.result
     end
   end
 
-  defmacro transaction!(term) do
+  defmacro sync_transaction(term) do
     quote do
       :mnesia.sync_transaction(unquote(term)) |> Amnesia.result
     end
@@ -172,8 +172,8 @@ defmodule Amnesia do
   Start a synchronous transaction with the given function passing the passed
   arguments to it, see `mnesia:sync_transaction`.
   """
-  @spec transaction!(function, list) :: any | no_return
-  def transaction!(fun, args) when is_function fun, length args do
+  @spec sync_transaction(function, list) :: any | no_return
+  def sync_transaction(fun, args) when is_function fun, length args do
     :mnesia.sync_transaction(fun, args) |> Amnesia.result
   end
 
@@ -182,8 +182,8 @@ defmodule Amnesia do
   arguments to it, trying to take a lock maximum *retries* times, see
   `mnesia:sync_transaction`.
   """
-  @spec transaction!(function, list, integer) :: any | no_return
-  def transaction!(fun, args, retries) when is_function fun, length args do
+  @spec sync_transaction(function, list, integer) :: any | no_return
+  def sync_transaction(fun, args, retries) when is_function fun, length args do
     :mnesia.sync_transaction(fun, args, retries) |> Amnesia.result
   end
 
@@ -193,7 +193,7 @@ defmodule Amnesia do
   @spec ets([do: term] | term) :: any
   defmacro ets(do: block) do
     quote do
-      :mnesia.ets(function(do: (() -> unquote(block)))) |> Amnesia.result
+      :mnesia.ets(fn -> unquote(block) end) |> Amnesia.result
     end
   end
 
@@ -219,7 +219,7 @@ defmodule Amnesia do
   @spec async([do: term] | term) :: any
   defmacro async(do: block) do
     quote do
-      :mnesia.async_dirty(function(do: (() -> unquote(block)))) |> Amnesia.result
+      :mnesia.async_dirty(fn -> unquote(block) end) |> Amnesia.result
     end
   end
 
@@ -245,7 +245,7 @@ defmodule Amnesia do
   @spec sync([do: term] | term) :: any
   defmacro sync(do: block) do
     quote do
-      :mnesia.sync_dirty(function(do: (() -> unquote(block)))) |> Amnesia.result
+      :mnesia.sync_dirty(fn -> unquote(block) end) |> Amnesia.result
     end
   end
 

--- a/lib/amnesia/access.ex
+++ b/lib/amnesia/access.ex
@@ -158,8 +158,7 @@ defmodule Amnesia.Access do
       defmacro transaction(do: block) do
         quote do
           try do
-            { :atomic, :mnesia.activity(:transaction,
-              function(do: (() -> unquote(block))), [], unquote(@target)) }
+            { :atomic, :mnesia.activity(:transaction, fn -> unquote(block) end, [], unquote(@target)) }
           catch
             :exit, error -> error
           end |> Amnesia.result
@@ -210,7 +209,7 @@ defmodule Amnesia.Access do
       defmacro transaction!(do: block) do
         quote do
           try do
-            { :atomic, :mnesia.activity(:sync_transaction, function(do: (() -> unquote(block))), [], unquote(@target)) }
+            { :atomic, :mnesia.activity(:sync_transaction, fn -> unquote(block) end, [], unquote(@target)) }
           catch
             :exit, error -> error
           end |> Amnesia.result
@@ -260,7 +259,7 @@ defmodule Amnesia.Access do
       @spec ets([] | function) :: any | no_return
       defmacro ets(do: block) do
         quote do
-          :mnesia.activity(:ets, function(do: (() -> unquote(block))), [], unquote(@target))
+          :mnesia.activity(:ets, fn -> unquote(block) end, [], unquote(@target))
         end
       end
 
@@ -286,7 +285,7 @@ defmodule Amnesia.Access do
       @spec async([] | function) :: any | no_return
       defmacro async(do: block) do
         quote do
-          :mnesia.activity(:async_dirty, function(do: (() -> unquote(block))), [], unquote(@target))
+          :mnesia.activity(:async_dirty, fn -> unquote(block) end, [], unquote(@target))
         end
       end
 
@@ -312,7 +311,7 @@ defmodule Amnesia.Access do
       @spec sync([] | function) :: any | no_return
       defmacro sync(do: block) do
         quote do
-          :mnesia.activity(:sync_dirty, function(do: (() -> unquote(block))), [], unquote(@target))
+          :mnesia.activity(:sync_dirty, fn -> unquote(block) end, [], unquote(@target))
         end
       end
 

--- a/test/database_test.exs
+++ b/test/database_test.exs
@@ -48,7 +48,7 @@ defmodule DatabaseTest do
   end
 
   test "saves item" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       user = User[id: 23]
       user.add_message("yo dawg")
       user.write
@@ -56,7 +56,7 @@ defmodule DatabaseTest do
 
     Enum.first(User.read!(23).messages!).user!
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.read(23) == User[id: 23]
       assert User.read(23).messages == [Message[user_id: 23, content: "yo dawg"]]
       assert Enum.first(User.read(23).messages).user == User[id: 23]
@@ -64,159 +64,159 @@ defmodule DatabaseTest do
   end
 
   test "read returns nil when empty" do
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.read(23) == nil
       assert Message.read(23) == nil
     end == true)
   end
 
   test "first fetches a key" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.first(true) == 1
     end == true)
   end
 
   test "first fetches the record" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.first == User[id: 1, name: "John"]
     end == true)
   end
 
   test "next fetches the next key" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.next(User.first(true)) == 2
     end == true)
   end
 
   test "next fetches the next record" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.first.next == User[id: 2, name: "Lucas"]
     end == true)
   end
 
   test "prev fetches the prev key" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.prev(User.last(true)) == 2
     end == true)
   end
 
   test "prev fetches the prev record" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.last.prev == User[id: 2, name: "Lucas"]
     end == true)
   end
 
   test "last fetches a key" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.last(true) == 3
     end == true)
   end
 
   test "last fetches the record" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.last == User[id: 3, name: "David"]
     end == true)
   end
 
   test "delete deletes the record" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.last == User[id: 3, name: "David"]
       assert User.last.delete == :ok
     end == true)
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.last == User[id: 2, name: "Lucas"]
     end == true)
   end
 
   test "match matches records" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.match(User[name: "Lucas", _: :_]).values ==
         [User[id: 2, name: "Lucas"]]
     end == true)
   end
 
   test "select works" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert User.select([{ User[id: :'$1', name: :'$2', _: :_],
         [{ :'==', "John", :'$2' }], [:'$1'] }]).values == [1]
     end == true)
   end
 
   test "select works with limit" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       selection = User.select(1, [{ User[id: :'$1', _: :_], [], [:'$1'] }])
       assert selection.values == [1]
 
@@ -232,13 +232,13 @@ defmodule DatabaseTest do
 
 
   test "enumerator works" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert Enum.map(User.to_sequence, fn(user) ->
         user.id
       end) == [1, 2, 3]
@@ -246,13 +246,13 @@ defmodule DatabaseTest do
   end
 
   test "reverse enumerator works" do
-    Amnesia.transaction! do
+    Amnesia.sync_transaction do
       User[id: 1, name: "John"].write
       User[id: 2, name: "Lucas"].write
       User[id: 3, name: "David"].write
     end
 
-    assert(Amnesia.transaction! do
+    assert(Amnesia.sync_transaction do
       assert Enum.map(User.to_sequence.reverse, fn(user) ->
         user.id
       end) == [3, 2, 1]


### PR DESCRIPTION
Hello, and thank you for Amnesia!

I haven't been able to use Amnesia with Elixir 0.10.1. My client code and database_test.exs wouldn't compile because of a syntax error on the line calling Amnesia.transaction!:

```
$ mix test
** (SyntaxError) /Users/mathieul/Documents/Development/Vendor/amnesia/test/database_test.exs:51: syntax error before: do
    /private/tmp/elixir-IDpY/elixir-0.10.1/lib/elixir/lib/code.ex:291: Code.require_file/2
    /private/tmp/elixir-IDpY/elixir-0.10.1/lib/elixir/lib/kernel/parallel_require.ex:48: Kernel.ParallelRequire."-spawn_requires/5-fun-0-"/5
```

I'm pretty new at Elixir, and didn't find the cause. But I found that just renaming it without a "!" did fix it. So I renamed it to the original mnesia method name.

Also the function/do syntax is now deprecated, so I replaced those calls with fn -> ... end.

Cheers,

Mathieu
