### PR TITLE
Allow Amnesia.result to work with async, not just transaction

### DIFF
--- a/lib/amnesia.ex
+++ b/lib/amnesia.ex
@@ -193,13 +193,13 @@ defmodule Amnesia do
   @spec ets([do: term] | term) :: any
   defmacro ets(do: block) do
     quote do
-      :mnesia.ets(fn -> unquote(block) end) |> Amnesia.result
+      :mnesia.ets(fn -> unquote(block) end)
     end
   end
 
   defmacro ets(term) do
     quote do
-      :mnesia.ets(unquote(term)) |> Amnesia.result
+      :mnesia.ets(unquote(term))
     end
   end
 
@@ -209,7 +209,7 @@ defmodule Amnesia do
   """
   @spec ets(function, list) :: any
   def ets(fun, args) when is_function fun, length args do
-    :mnesia.ets(fun, args) |> Amnesia.result
+    :mnesia.ets(fun, args)
   end
 
   @doc """
@@ -219,13 +219,13 @@ defmodule Amnesia do
   @spec async([do: term] | term) :: any
   defmacro async(do: block) do
     quote do
-      :mnesia.async_dirty(fn -> unquote(block) end) |> Amnesia.result
+      :mnesia.async_dirty(fn -> unquote(block) end)
     end
   end
 
   defmacro async(term) do
     quote do
-      :mnesia.async_dirty(unquote(term)) |> Amnesia.result
+      :mnesia.async_dirty(unquote(term))
     end
   end
 
@@ -235,7 +235,7 @@ defmodule Amnesia do
   """
   @spec async(function, list) :: any
   def async(fun, args) when is_function fun, length args do
-    :mnesia.async_dirty(fun, args) |> Amnesia.result
+    :mnesia.async_dirty(fun, args)
   end
 
   @doc """
@@ -245,13 +245,13 @@ defmodule Amnesia do
   @spec sync([do: term] | term) :: any
   defmacro sync(do: block) do
     quote do
-      :mnesia.sync_dirty(fn -> unquote(block) end) |> Amnesia.result
+      :mnesia.sync_dirty(fn -> unquote(block) end)
     end
   end
 
   defmacro sync(term) do
     quote do
-      :mnesia.sync_dirty(unquote(term)) |> Amnesia.result
+      :mnesia.sync_dirty(unquote(term))
     end
   end
 
@@ -261,7 +261,7 @@ defmodule Amnesia do
   """
   @spec sync(function, list) :: any
   def sync(fun, args) when is_function fun, length args do
-    :mnesia.sync_dirty(fun, args) |> Amnesia.result
+    :mnesia.sync_dirty(fun, args)
   end
 
   @doc """

--- a/test/database_test.exs
+++ b/test/database_test.exs
@@ -71,6 +71,35 @@ defmodule DatabaseTest do
     end == true)
   end
 
+  test "async dirty functionality works" do
+    Amnesia.async do
+      user = User[id: 23]
+      user.add_message("yo dawg")
+      user.write
+    end
+
+    assert(Amnesia.async do
+      assert User.read(23) == User[id: 23]
+      assert User.read(23).messages == [Message[user_id: 23, content: "yo dawg"]]
+      assert Seq.first(User.read(23).messages).user == User[id: 23]
+    end == true)
+  end
+
+  
+  test "sync dirty functionality works" do
+    Amnesia.sync do
+      user = User[id: 23]
+      user.add_message("yo dawg")
+      user.write
+    end
+
+    assert(Amnesia.sync do
+      assert User.read(23) == User[id: 23]
+      assert User.read(23).messages == [Message[user_id: 23, content: "yo dawg"]]
+      assert Seq.first(User.read(23).messages).user == User[id: 23]
+    end == true)
+  end
+
   test "first fetches a key" do
     Amnesia.transaction! do
       User[id: 1, name: "John"].write


### PR DESCRIPTION
When using `Amnesia.async`, the return value is not `{:atomic, value}` so there is no match for the result.
