### PR TITLE
Remove unused continuum dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,6 @@ defmodule Amnesia.Mixfile do
   end
 
   defp deps do
-    [ { :exquisite, "~> 0.1.2" },
-      { :continuum, github: "meh/continuum" } ]
+    [ { :exquisite, "~> 0.1.2" } ]
   end
 end


### PR DESCRIPTION
It seems that the continuum dependency is unused now, at least I didn't find anything within amnesia which would give me a hint that it's used and I could also compile it without.