### PR TITLE
avoid warning when calling the where macro

### DIFF
--- a/lib/amnesia/table/definition.ex
+++ b/lib/amnesia/table/definition.ex
@@ -740,24 +740,16 @@ defmodule Amnesia.Table.Definition do
         """
         defmacro where(spec, options \\ []) do
           options = Keyword.put(options, :where, spec)
+          lock = options[:lock]
+          limit = options[:limit]
 
-          quote do
-            lock  = unquote(options[:lock])
-            limit = unquote(options[:limit])
-
-            cond do
-              lock || limit ->
-                S.coerce(T.select(unquote(__MODULE__), lock || limit,
-                  unquote(D.where(__MODULE__, @attributes, options))), unquote(__MODULE__))
-
-              lock && limit ->
-                S.coerce(T.select(unquote(__MODULE__), lock, limit,
-                  unquote(D.where(__MODULE__, @attributes, options))), unquote(__MODULE__))
-
-              true ->
-                S.coerce(T.select(unquote(__MODULE__),
-                  unquote(D.where(__MODULE__, @attributes, options))), unquote(__MODULE__))
-            end
+          cond do
+            lock || limit ->
+              quote do: S.coerce(T.select(unquote(__MODULE__), unquote(lock || limit), unquote(D.where(__MODULE__, @attributes, options))), unquote(__MODULE__))
+            lock && limit ->
+              quote do: S.coerce(T.select(unquote(__MODULE__), unquote(lock), unquote(limit), unquote(D.where(__MODULE__, @attributes, options))), unquote(__MODULE__))
+            true ->
+              quote do: S.coerce(T.select(unquote(__MODULE__), unquote(D.where(__MODULE__, @attributes, options))), unquote(__MODULE__))
           end
         end
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,6 @@ defmodule Amnesia.Mixfile do
   end
 
   defp deps do
-    [ { :exquisite, "~> 0.1.2" },
-      { :continuum, github: "meh/continuum" } ]
+    [ { :exquisite, "~> 0.1.4" } ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
 %{"continuum": {:git, "git://github.com/meh/continuum.git", "4125f9d428971568f16da78cec24fddce18d6eca", []},
   "datastructures": {:git, "git://github.com/meh/elixir-datastructures.git", "28a7aee9addfe521ad0aa62f5e54f1ad597356cc", []},
-  "exquisite": {:package, "0.1.4"}}
+  "exquisite": {:hex, :exquisite, "0.1.4"}}


### PR DESCRIPTION
The where macro generates a "cond" block, but the result of that cond is actually determined at compile time, at runtime it will always be the same. I reorganized the macro a little to have the cond block executed during compilation and only return the correct quoted expression, which makes the warning disappear (and is slightly more efficient).