### PR TITLE
Added the user_properties field to table create

### DIFF
--- a/lib/amnesia/table.ex
+++ b/lib/amnesia/table.ex
@@ -77,6 +77,10 @@ defmodule Amnesia.Table do
       args = Keyword.put(args, :load_order, priority)
     end
 
+    if user = definition[:user] do
+      args = Keyword.put(args, :user_properties, user)
+    end
+
     if local = definition[:local] do
       args = Keyword.put(args, :local_content, local)
     end


### PR DESCRIPTION
added the :user tag for :mnesia.create_table.  This is needed if you want to use unsplit (https://github.com/uwiger/unsplit).  My guess it was just overlooked because it is not a widely used field.

