### PR TITLE
Added exquisite to the applications: list in mix.exs

### DIFF
--- a/lib/amnesia/table.ex
+++ b/lib/amnesia/table.ex
@@ -77,6 +77,10 @@ defmodule Amnesia.Table do
       args = Keyword.put(args, :load_order, priority)
     end
 
+    if user = definition[:user] do
+      args = Keyword.put(args, :user_properties, user)
+    end
+
     if local = definition[:local] do
       args = Keyword.put(args, :local_content, local)
     end

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Amnesia.Mixfile do
   end
 
   def application do
-    [ applications: [:mnesia, :logger] ]
+    [ applications: [:mnesia, :logger, :exquisite] ]
   end
 
   defp deps do


### PR DESCRIPTION
For folks using exrm it would be nice to have :exquisite added to this list so they only need to add :amnesia to their mix.exs.  If they don't remember to add :exquisite the packager will not include exquisite and any use of the select will generate a runtime error.