### PR TITLE
Wait for db before trying to drop it, from within the mix task

### DIFF
--- a/lib/mix/amnesia.drop.ex
+++ b/lib/mix/amnesia.drop.ex
@@ -10,6 +10,7 @@ defmodule Mix.Tasks.Amnesia.Drop do
     db = ensure_database_module(options[:database])
 
     Amnesia.start
+    db.wait
     db.destroy
     Amnesia.stop
 


### PR DESCRIPTION
I was experiencing some issues when dropping and re-creating a db from scratch using the mix tasks. The dropping step seemed to leave some resources in place because subsequent the create task would always fail, saying the DB already existed.

This change fixes that.