### PR TITLE
application code changed to Elixir 1.3 style, tests pass

### DIFF
--- a/lib/mix/amnesia.create.ex
+++ b/lib/mix/amnesia.create.ex
@@ -39,10 +39,10 @@ defmodule Mix.Tasks.Amnesia.Create do
 
     # defaults to disk
     if Enum.empty?(copying) do
-      copying = [disk: [node]]
+      [disk: [node]]
+    else
+      copying
     end
-    
-    copying
   end
   
   defp parse_args([]) do
@@ -67,9 +67,9 @@ defmodule Mix.Tasks.Amnesia.Create do
     end
 
     if is_nil(options[:schema]) do
-      options = Keyword.put(options, :schema, true)
+      Keyword.put(options, :schema, true)
+    else
+      options
     end
-
-    options
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Amnesia.Mixfile do
   def project do
     [ app: :amnesia,
       version: "0.2.3",
-      elixir: "~> 1.0.0-rc1 or ~> 1.1.0-rc.0 or ~> 1.2.0-rc.0",
+      elixir: "~> 1.0.0-rc1 or ~> 1.1.0-rc.0 or ~> 1.2.0-rc.0 or ~> 1.3.0-dev",
       deps: deps,
       package: package,
       description: "mnesia wrapper for Elixir" ]


### PR DESCRIPTION
Hello.

I was experiencing lots of compile warnings when working with latest Elixir 1.2.5 or 1.3.0-dev due to a change that discourages constructs like this:

```
args = ...
if ... do
  args = ...
end
```

I tried to convert this to something that doesn't require this construct - maybe you like, maybe not. There's several ways to do it and I applied at least two. Take your pick. :wink: 

Two issues remain:
* I did not know where to put my new function `update_keyword/3` and did not want to impose a location.
* Not sure if the following was intentional in the original code:
```
    if options[:skip] do
      args = Keyword.put(args, :skip_tables, normalize(options[:keep]))
    end
```

I was not sure if this was a copy-paste error so I left it in.