### PR TITLE
Fix some warnings caused by Elxir 1.3.0, as well as a few typos.

### DIFF
--- a/lib/amnesia/database.ex
+++ b/lib/amnesia/database.ex
@@ -41,10 +41,10 @@ defmodule Amnesia.Database do
               to = Module.split(module)
                 |> Enum.drop(Module.split(__MODULE__) |> length)
 
-              if length(to) > 1 do
-                to = Module.concat(__MODULE__, to |> hd)
+              to = if length(to) > 1 do
+                Module.concat(__MODULE__, to |> hd)
               else
-                to = module
+                module
               end
 
               [ quote(do: alias unquote(to)),

--- a/lib/amnesia/metadata.ex
+++ b/lib/amnesia/metadata.ex
@@ -116,5 +116,5 @@ defmodule Amnesia.Metadata do
     :mnesia.dirty_update_counter(database, { table, field }, value)
   end
 
-  defdelegate counter(self, table, field, value), to: __MODULE__, as: :counter!
+  defdelegate counter!(self, table, field, value), to: __MODULE__, as: :counter
 end

--- a/lib/amnesia/table.ex
+++ b/lib/amnesia/table.ex
@@ -331,7 +331,7 @@ defmodule Amnesia.Table do
   """
   @spec move_copy(atom, node, node) :: o
   def move_copy(name, from, to) do
-    :mnesia.move_copy(name, from, to) |> result
+    :mnesia.move_table_copy(name, from, to) |> result
   end
 
   @doc """


### PR DESCRIPTION
Fixed a few small issues. There is one warning I can't figure out how to get rid of easily. It seems to be caused by referencing a macro in the top-level Amnesia module from itself -- this seems to work because it is mostly used by mixin?

```
warning: function Amnesia.result/1 is undefined or private
Found at 7 locations:
Fix some warnings caused by Elxir 1.3.0, as well as a few typos.
  lib/amnesia.ex:159
  lib/amnesia.ex:168
  lib/amnesia.ex:194
  lib/amnesia.ex:204
  lib/amnesia.ex:229
  lib/amnesia.ex:255
  lib/amnesia.ex:281
```

The rest were typos or whatever.