### PR TITLE
Get rid of compiler warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Creating the database
 Before using a database you have to create it, and before it a schema.
 
 To do so, you can use the built-in mix task `amnesia.create` passing your
-database module via the `--database` or `-db` options.
+database module via the `--database` or `-d` options.
 
 ```sh
-mix amnesia.create -db Database --disk
+mix amnesia.create -d Database --disk
 ```
 
 The available options for creating the databases are:
 
-- `--database` or `-db`: the database module to create
+- `--database` or `-d`: the database module to create
 - `--no-schema`: to avoid creating the schema
 - `--memory`: to create the tables with memory copying on the current node
 - `--disk`: to create the tables with disc_copies on the current node
@@ -104,12 +104,12 @@ If you want to drop the tables there is also a drop task you should use with
 __CAUTION__ as it will destroy all data. To use it just call:
 
 ```sh
-mix amnesia.drop -db Database
+mix amnesia.drop -d Database
 ```
 
 The options accepted by this task are:
 
-- `--database` or `-db`: same as with create. A database module to drop tables
+- `--database` or `-d`: same as with create. A database module to drop tables
 - `--schema`: drops the schema too. Defaults to false
 
 Writing to the database

--- a/lib/amnesia/access.ex
+++ b/lib/amnesia/access.ex
@@ -15,33 +15,31 @@ defmodule Amnesia.Access do
   `mnesia:activity`.
   """
 
-  use Behaviour
-
   @opaque id :: { :tid, integer, pid } | { :async_dirty, pid } | { :sync_dirty, pid } | { :ets, pid }
 
   @type lock_item :: { :table, atom } | { :global, any, [node] }
   @type lock_kind :: :write | :read | :sticky_write
 
-  defcallback lock(id, any, lock_item, lock_kind) :: [node] | :ok | no_return
-  defcallback write(id, any, atom, tuple, lock_kind) :: :ok | no_return
-  defcallback delete(id, any, atom, any, lock_kind) :: :ok | no_return
-  defcallback delete_object(id, any, atom, tuple, lock_kind) :: :ok | no_return
-  defcallback read(id, any, atom, any, lock_kind) :: [tuple] | no_return
-  defcallback match_object(id, any, atom, any, lock_kind) :: [any] | no_return
-  defcallback all_keys(id, any, atom, lock_kind) :: [any] | no_return
-  defcallback select(id, any, atom, any, lock_kind) :: [any]
-  defcallback select(id, any, atom, any, integer, lock_kind) :: [any]
-  defcallback select_cont(id, any, any) :: :'$end_of_table' | { [any], any }
-  defcallback index_match_object(id, any, atom, any, atom | integer, lock_kind) :: [any] | no_return
-  defcallback index_read(id, any, atom, any, atom | integer, lock_kind) :: [tuple] | no_return
-  defcallback foldl(id, any, (tuple, any -> any), any, atom, lock_kind) :: any | no_return
-  defcallback foldr(id, any, (tuple, any -> any), any, atom, lock_kind) :: any | no_return
-  defcallback table_info(id, any, atom | { atom, atom }, atom) :: any
-  defcallback first(id, any, atom) :: any
-  defcallback next(id, any, atom, any) :: any
-  defcallback prev(id, any, atom, any) :: any
-  defcallback last(id, any, atom) :: any
-  defcallback clear_table(id, any, atom, any) :: { :atomic, :ok } | { :aborted, any }
+  @callback lock(id, any, lock_item, lock_kind) :: [node] | :ok | no_return
+  @callback write(id, any, atom, tuple, lock_kind) :: :ok | no_return
+  @callback delete(id, any, atom, any, lock_kind) :: :ok | no_return
+  @callback delete_object(id, any, atom, tuple, lock_kind) :: :ok | no_return
+  @callback read(id, any, atom, any, lock_kind) :: [tuple] | no_return
+  @callback match_object(id, any, atom, any, lock_kind) :: [any] | no_return
+  @callback all_keys(id, any, atom, lock_kind) :: [any] | no_return
+  @callback select(id, any, atom, any, lock_kind) :: [any]
+  @callback select(id, any, atom, any, integer, lock_kind) :: [any]
+  @callback select_cont(id, any, any) :: :'$end_of_table' | { [any], any }
+  @callback index_match_object(id, any, atom, any, atom | integer, lock_kind) :: [any] | no_return
+  @callback index_read(id, any, atom, any, atom | integer, lock_kind) :: [tuple] | no_return
+  @callback foldl(id, any, (tuple, any -> any), any, atom, lock_kind) :: any | no_return
+  @callback foldr(id, any, (tuple, any -> any), any, atom, lock_kind) :: any | no_return
+  @callback table_info(id, any, atom | { atom, atom }, atom) :: any
+  @callback first(id, any, atom) :: any
+  @callback next(id, any, atom, any) :: any
+  @callback prev(id, any, atom, any) :: any
+  @callback last(id, any, atom) :: any
+  @callback clear_table(id, any, atom, any) :: { :atomic, :ok } | { :aborted, any }
 
   @spec lock(id, any, lock_item, lock_kind) :: [node] | :ok | no_return
   def lock(id, opaque, item, kind) do

--- a/lib/amnesia/backup.ex
+++ b/lib/amnesia/backup.ex
@@ -12,7 +12,6 @@ defmodule Amnesia.Backup do
   use backups.
   """
 
-  use Behaviour
   alias Amnesia.Helper.Options
 
   @type o :: { :ok, any } | { :error, any }
@@ -24,37 +23,37 @@ defmodule Amnesia.Backup do
   @doc """
   Open the backup for writing.
   """
-  defcallback open_write(any) :: o
+  @callback open_write(any) :: o
 
   @doc """
   Write the given terms to the backup.
   """
-  defcallback write(any, [any]) :: o
+  @callback write(any, [any]) :: o
 
   @doc """
   Commit the write to the backup.
   """
-  defcallback commit_write(any) :: o
+  @callback commit_write(any) :: o
 
   @doc """
   Close the backup if the backup is interrupted.
   """
-  defcallback abort_write(any) :: o
+  @callback abort_write(any) :: o
 
   @doc """
   Open the backup for reading.
   """
-  defcallback open_read(any) :: o
+  @callback open_read(any) :: o
 
   @doc """
   Read terms from the backup.
   """
-  defcallback read(any) :: { :ok, any, [any] } | { :error, any }
+  @callback read(any) :: { :ok, any, [any] } | { :error, any }
 
   @doc """
   Close the backup.
   """
-  defcallback close_read(any) :: o
+  @callback close_read(any) :: o
 
   @doc """
   Create a checkpoint, see `mnesia:activate_checkpoint`.
@@ -63,7 +62,7 @@ defmodule Amnesia.Backup do
   def checkpoint(options) do
     args = Keyword.new
 
-    args = 
+    args =
       if options[:remote] do
         Keyword.put_new(args, :allow_remote, options[:remote])
       else

--- a/lib/amnesia/database.ex
+++ b/lib/amnesia/database.ex
@@ -66,7 +66,7 @@ defmodule Amnesia.Database do
         @spec create :: [Amnesia.Table.o]
         @spec create(Amnesia.Table.c) :: [Amnesia.Table.o]
         def create(copying \\ []) do
-          [ metadata |> Metadata.create(copying: copying) |
+          [ metadata() |> Metadata.create(copying: copying) |
 
             Enum.map(@tables, fn(table) ->
               table.create(copying)
@@ -80,7 +80,7 @@ defmodule Amnesia.Database do
         @spec create! :: [Amnesia.Table.o]
         @spec create!(Amnesia.Table.c) :: [Amnesia.Table.o]
         def create!(copying \\ []) do
-          metadata |> Metadata.create!(copying: copying)
+          metadata() |> Metadata.create!(copying: copying)
 
           Enum.each @tables, fn(table) ->
             table.create!(copying)
@@ -92,7 +92,7 @@ defmodule Amnesia.Database do
         """
         @spec destroy :: [Amnesia.Table.o]
         def destroy do
-          [ metadata |> Metadata.destroy |
+          [ metadata() |> Metadata.destroy |
 
             Enum.map(@tables, fn(table) ->
               table.destroy
@@ -105,7 +105,7 @@ defmodule Amnesia.Database do
         """
         @spec destroy! :: [Amnesia.Table.o]
         def destroy! do
-          metadata |> Metadata.destroy!
+          metadata() |> Metadata.destroy!
 
           Enum.each @tables, fn(table) ->
             table.destroy!

--- a/lib/amnesia/fragment/hash.ex
+++ b/lib/amnesia/fragment/hash.ex
@@ -12,30 +12,28 @@ defmodule Amnesia.Fragment.Hash do
   algorithm.
   """
 
-  use Behaviour
-
   @doc """
   Initialize the hash state.
   """
-  defcallback init_state(atom, any) :: any
+  @callback init_state(atom, any) :: any
 
   @doc """
   Add a fragment returning the new fragment numbers and state.
   """
-  defcallback add_frag(any) :: { any, [integer], [integer] }
+  @callback add_frag(any) :: { any, [integer], [integer] }
 
   @doc """
   Delete a fragment returning the new fragment numbers and state.
   """
-  defcallback del_frag(any) :: { any, [integer], [integer] }
+  @callback del_frag(any) :: { any, [integer], [integer] }
 
   @doc """
   Convert a key to a fragment number.
   """
-  defcallback key_to_frag_number(any, any) :: integer
+  @callback key_to_frag_number(any, any) :: integer
 
   @doc """
   Convert a match_spec to fragment numbers.
   """
-  defcallback match_spec_to_frag_numbers(any, any) :: [integer]
+  @callback match_spec_to_frag_numbers(any, any) :: [integer]
 end

--- a/lib/amnesia/schema.ex
+++ b/lib/amnesia/schema.ex
@@ -28,7 +28,7 @@ defmodule Amnesia.Schema do
   """
   @spec create :: :ok | { :error, any }
   @spec create([node]) :: :ok | { :error, any }
-  def create(nodes \\ [node]) do
+  def create(nodes \\ [node()]) do
     :mnesia.create_schema(nodes)
   end
 
@@ -37,7 +37,7 @@ defmodule Amnesia.Schema do
   """
   @spec destroy :: :ok | { :error, any }
   @spec destroy([node]) :: :ok | { :error, any }
-  def destroy(nodes \\ [node]) do
+  def destroy(nodes \\ [node()]) do
     :mnesia.delete_schema(nodes)
   end
 end

--- a/lib/amnesia/table/definition.ex
+++ b/lib/amnesia/table/definition.ex
@@ -32,7 +32,7 @@ defmodule Amnesia.Table.Definition do
   @doc false
   def match(module, pattern) do
     [module | for { key, _ } <- module.attributes do
-      if Dict.has_key?(pattern, key), do: pattern[key], else: :_
+      if Keyword.has_key?(pattern, key), do: pattern[key], else: :_
     end] |> List.to_tuple
   end
 

--- a/lib/mix/amnesia.create.ex
+++ b/lib/mix/amnesia.create.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Amnesia.Create do
     if options[:schema] do
       Amnesia.Schema.create
     end
-    
+
     Amnesia.start
     try do
       db.create!(copying)
@@ -27,11 +27,11 @@ defmodule Mix.Tasks.Amnesia.Create do
     copying = Enum.reduce options, [], fn({key, val}, acc) ->
       case {key, val} do
         {:disk, true} ->
-          Keyword.put acc, :disk, [node]
+          Keyword.put acc, :disk, [node()]
         {:disk!, true} ->
-          Keyword.put acc, :disk!, [node]
+          Keyword.put acc, :disk!, [node()]
         {:memory, true} ->
-          Keyword.put acc, :memory, [node]
+          Keyword.put acc, :memory, [node()]
         _ ->
           acc
       end
@@ -39,12 +39,12 @@ defmodule Mix.Tasks.Amnesia.Create do
 
     # defaults to disk
     if Enum.empty?(copying) do
-      [disk: [node]]
+      [disk: [node()]]
     else
       copying
     end
   end
-  
+
   defp parse_args([]) do
     Mix.raise "No database option. Please provide one."
   end

--- a/lib/mix/amnesia.drop.ex
+++ b/lib/mix/amnesia.drop.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Amnesia.Drop do
   defp parse_args(args) do
     {options, _, _} = OptionParser.parse(args, [
           aliases: [
-            db: :database
+            d: :database
           ],
           strict: [
             database: :string,
@@ -31,5 +31,5 @@ defmodule Mix.Tasks.Amnesia.Drop do
         ])
     options
   end
-  
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Amnesia.Mixfile do
   def project do
     [ app: :amnesia,
       version: "0.2.5",
-      deps: deps,
-      package: package,
+      deps: deps(),
+      package: package(),
       description: "mnesia wrapper for Elixir" ]
   end
 

--- a/test/mix/amnesia_create_test.exs
+++ b/test/mix/amnesia_create_test.exs
@@ -40,7 +40,7 @@ defdatabase Create.Database do
 end
 
 defmodule Create.NotADatabase do
-  
+
 end
 
 # ordered_set cannot be used with disk! copying
@@ -60,7 +60,7 @@ defmodule Mix.Tasks.Amnesia.Create.Test do
     Amnesia.stop
     Amnesia.Schema.destroy
   end
-  
+
   test "creates schema and tables" do
     Create.run(["--database", "Create.Database"])
 
@@ -87,9 +87,9 @@ defmodule Mix.Tasks.Amnesia.Create.Test do
     assert User in tables
     assert Message in tables
     assert DB in tables
-    assert Amnesia.Table.info(User, :disc_copies) == [node]
-    assert Amnesia.Table.info(Message, :disc_copies) == [node]
-    assert Amnesia.Table.info(DB, :disc_copies) == [node]
+    assert Amnesia.Table.info(User, :disc_copies) == [node()]
+    assert Amnesia.Table.info(Message, :disc_copies) == [node()]
+    assert Amnesia.Table.info(DB, :disc_copies) == [node()]
   end
 
   test "creates database with disk! option" do
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Amnesia.Create.Test do
     assert :schema in tables
     assert DiscOnly.Database.Message in tables
     assert DiscOnly.Database in tables
-    assert Amnesia.Table.info(DiscOnly.Database.Message, :disc_only_copies) == [node]
+    assert Amnesia.Table.info(DiscOnly.Database.Message, :disc_only_copies) == [node()]
   end
-  
+
 end

--- a/test/mix/amnesia_drop_test.exs
+++ b/test/mix/amnesia_drop_test.exs
@@ -53,17 +53,17 @@ defmodule Mix.Tasks.Amnesia.Drop.Test do
     Amnesia.Schema.create
     Amnesia.start
 
-    DB.create(memory: [node])
+    DB.create(memory: [node()])
     :ok = DB.wait 15000
     Amnesia.stop
 
     on_exit fn -> Amnesia.stop end
-  end  
+  end
 
   test "drops tables and schema" do
     Drop.run(["-db", "Drop.Database", "--schema"])
     Amnesia.start
-    assert Amnesia.info(:tables) == [:schema] # this table exists 
+    assert Amnesia.info(:tables) == [:schema] # this table exists
   end
 
   test "detects module is not a database" do

--- a/test/mix/amnesia_drop_test.exs
+++ b/test/mix/amnesia_drop_test.exs
@@ -61,14 +61,14 @@ defmodule Mix.Tasks.Amnesia.Drop.Test do
   end
 
   test "drops tables and schema" do
-    Drop.run(["-db", "Drop.Database", "--schema"])
+    Drop.run(["-d", "Drop.Database", "--schema"])
     Amnesia.start
     assert Amnesia.info(:tables) == [:schema] # this table exists
   end
 
   test "detects module is not a database" do
     assert_raise Mix.Error, fn ->
-      Drop.run(["-db", "Drop.NotADatabase"])
+      Drop.run(["-d", "Drop.NotADatabase"])
     end
   end
 


### PR DESCRIPTION
The only thing missing now is `warning: multi-letter aliases are deprecated, got: :db` e.g. when running the tests:

```
warning: multi-letter aliases are deprecated, got: :db
  (elixir) lib/option_parser.ex:351: OptionParser.next/4
  (elixir) lib/option_parser.ex:255: OptionParser.do_parse/6
  (amnesia) lib/mix/amnesia.drop.ex:23: Mix.Tasks.Amnesia.Drop.parse_args/1
  (amnesia) lib/mix/amnesia.drop.ex:9: Mix.Tasks.Amnesia.Drop.run/1
  test/mix/amnesia_drop_test.exs:64: Mix.Tasks.Amnesia.Drop.Test."test drops tables and schema"/1
```

I've found the deprecation in the [`CHANGELOG`](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#elixir-3) but don't quite get what it means 😅