### PR TITLE
Fixes #60: addresses -d option

### DIFF
--- a/lib/mix/amnesia.create.ex
+++ b/lib/mix/amnesia.create.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Amnesia.Create do
   defp parse_args(args) when is_list(args) do
     {options, _, _} = OptionParser.parse(args, [
           aliases: [
-            db: :database
+            d: :database
           ],
           strict: [
             database: :string,

--- a/test/mix/amnesia_create_test.exs
+++ b/test/mix/amnesia_create_test.exs
@@ -61,8 +61,19 @@ defmodule Mix.Tasks.Amnesia.Create.Test do
     Amnesia.Schema.destroy
   end
 
-  test "creates schema and tables" do
+  test "creates schema and tables with --database" do
     Create.run(["--database", "Create.Database"])
+
+    Amnesia.start
+    tables = Amnesia.info(:tables)
+    assert :schema in tables
+    assert User in tables
+    assert Message in tables
+    assert DB in tables
+  end
+
+  test "creates schema and tables with -d" do
+    Create.run(["-d", "Create.Database"])
 
     Amnesia.start
     tables = Amnesia.info(:tables)


### PR DESCRIPTION
Fixes an issue with `-d` option for `mix amnesia.create` and adds a test for that option. 