### PR TITLE
Creating Mnesia directory before creating Schema

### DIFF
--- a/lib/amnesia/schema.ex
+++ b/lib/amnesia/schema.ex
@@ -29,6 +29,10 @@ defmodule Amnesia.Schema do
   @spec create :: :ok | { :error, any }
   @spec create([node]) :: :ok | { :error, any }
   def create(nodes \\ [node()]) do
+    if path = Application.get_env(:mnesia, :dir) do
+      File.mkdir_p(path)
+    end
+    
     :mnesia.create_schema(nodes)
   end
 


### PR DESCRIPTION
`:mnesia` lets you configure custom directories for the database but if the directory doesn't exist, it crashes when creating schema (in the case of nested directories). 

```elixir
config :mnesia, dir: 'mnesia/#{Mix.env}/#{node()}'
```

This also causes the `mix amnesia.create` task to crash for custom paths. This pull fixes this by creating the configured directory for `mnesia` before creating the schema (if the configuration value is specified).

