### PR TITLE
Remove deprecated char_list

### DIFF
--- a/lib/amnesia/event.ex
+++ b/lib/amnesia/event.ex
@@ -16,8 +16,8 @@ defmodule Amnesia.Event do
                   { :mnesia_checkpoint_activated, any } |
                   { :mnesia_overload, any } |
                   { :inconsistent_database, any } |
-                  { :mnesia_fatal, char_list, [any], binary } |
-                  { :mnesia_info, char_list, [any] } |
+                  { :mnesia_fatal, charlist, [any], binary } |
+                  { :mnesia_info, charlist, [any] } |
                   { :mnesia_user, any }
 
   @type activity :: { :complete, Amnesia.Access.id }


### PR DESCRIPTION
This PR removes the following deprecation warnings:

```shell
==> amnesia
Compiling 21 files (.ex)
warning: the char_list() type is deprecated, use charlist()
  lib/amnesia/event.ex:14

warning: the char_list() type is deprecated, use charlist()
  lib/amnesia/event.ex:14

Generated amnesia app
```