### PR TITLE
Fix defines_type?

### DIFF
--- a/lib/amnesia/table/definition.ex
+++ b/lib/amnesia/table/definition.ex
@@ -935,7 +935,7 @@ defmodule Amnesia.Table.Definition do
 
         unquote(block)
 
-        unless Kernel.Typespec.defines_type?(__MODULE__, :t, 0) do
+        unless Kernel.Typespec.defines_type?(__MODULE__, {:t, 0}) do
           @opaque t :: %__MODULE__{}
         end
       end


### PR DESCRIPTION
It changed from defines_type?/3 to defines_type?/2 where the last argument is a tuple.