### PR TITLE
remove unprofessional quote from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,6 @@ Amnesia.transaction do
   time, but it is slow in real time.
   """
 
-  richard |> User.add_message %S"""
-  I am skeptical of the claim that voluntarily pedophilia harms children. The
-  arguments that it causes harm seem to be based on cases which aren't
-  voluntary, which are then stretched by parents who are horrified by the idea
-  that their little baby is maturing.
-  """
-
   linus |> User.add_message %S"""
   Portability is for people who cannot write new programs.
   """


### PR DESCRIPTION
I'd like to use this library on a open source project, but I'm pretty sure the quote I'm suggesting for removal would violate our code of conduct.