### PR TITLE
Add formatter settings for deftable and defhook

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,12 +1,12 @@
 [
   inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: [
-    deftable: :*
+    deftable: :*,
     defhook: :*
   ],
   export: [
     locals_without_parens: [
-      deftable: :*
+      deftable: :*,
       defhook: :*
     ]
   ]

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,13 @@
+[
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: [
+    deftable: :*
+    defhook: :*
+  ],
+  export: [
+    locals_without_parens: [
+      deftable: :*
+      defhook: :*
+    ]
+  ]
+]


### PR DESCRIPTION
This PR adds settings for elixir built-in formatter that can be later used in `.formatter.exs` of one's project, e. g.

```elixir
[
  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
  import_deps: [:amnesia]
]
```